### PR TITLE
Make MyersDiff.isolateThreshold configurable at runtime

### DIFF
--- a/lib/implicitly_animated_reorderable_list.dart
+++ b/lib/implicitly_animated_reorderable_list.dart
@@ -1,5 +1,6 @@
 library implicitly_animated_reorderable_list;
 
+export 'src/diff/myers_diff.dart';
 export 'src/handle.dart';
 export 'src/implicitly_animated_list.dart';
 export 'src/implicitly_animated_reorderable_list.dart';

--- a/lib/src/diff/myers_diff.dart
+++ b/lib/src/diff/myers_diff.dart
@@ -16,7 +16,7 @@ class MyersDiff<E> {
   static ItemDiffUtil eq;
   static ItemDiffUtil cq;
 
-  static const int ISOLATE_THRESHOLD = 1500;
+  static int isolateThreshold = 1500;
 
   static Future<List<Diff>> withCallback<E>(
     DiffCallback<E> cb, {
@@ -43,7 +43,7 @@ class MyersDiff<E> {
 
     // We can significantly improve the performance by not spawning a new
     // isolate for shorter lists.
-    spawnIsolate ??= (newList.length * oldList.length) > ISOLATE_THRESHOLD;
+    spawnIsolate ??= (newList.length * oldList.length) > isolateThreshold;
     if (spawnIsolate) {
       return compute(_myersDiff, args);
     }


### PR DESCRIPTION
I have a situation where I'm dealing with lists of Protobuf data and getting some errors as soon as my list hits the isolate threshold. This is because [the method `_createDefaultMakerFor` returns a closure](https://github.com/dart-lang/protobuf/blob/master/protobuf/lib/src/protobuf/generated_message.dart#L500). There are arguably better ways around this (fixes in Flutter isolates themselves maybe?), but practical purposes, limiting my list to < 100 items and bumping the isolate threshold to 10,000+ is a fine solution.

*Testing*

I've verified locally with
```
implicitly_animated_reorderable_list: #0.1.10
      path: ../implicitly_animated_reorderable_list
```
in my project's pubspec.yaml and `MyersDiff.isolateThreshold = 15000;` in the Widget that has been giving me issues, issues are gone now.