### PR TITLE
Add support for draggable animation while nested in a scrollable

### DIFF
--- a/example/lib/ui/horizontal_nested_example.dart
+++ b/example/lib/ui/horizontal_nested_example.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:implicitly_animated_reorderable_list/implicitly_animated_reorderable_list.dart';
+
+class HorizontalNestedExample extends StatefulWidget {
+  const HorizontalNestedExample();
+
+  @override
+  State<StatefulWidget> createState() {
+    return HorizontalNestedExampleState();
+  }
+}
+
+class HorizontalNestedExampleState extends State<HorizontalNestedExample> {
+  List<String> nestedList = List.generate(20, (i) => "$i");
+  GlobalKey nestedListKey = GlobalKey();
+  bool nestedInReorder = false;
+  ScrollController nestedScrollController;
+  Drag nestedDrag;
+
+  @override
+  void initState() {
+    super.initState();
+    nestedScrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    nestedScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(
+          child: Container(
+            height: 100,
+            child: SingleChildScrollView(
+              key: nestedListKey,
+              scrollDirection: Axis.horizontal,
+              controller: nestedScrollController,
+              child: Row(
+                children: <Widget>[
+                  Card(
+                    child: Container(
+                        height: 100,
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: const Center(child: Text('Sibling Content'))),
+                  ),
+                  GestureDetector(
+                    onHorizontalDragStart: (DragStartDetails details) {
+                      nestedDrag = nestedScrollController.position
+                          .drag(details, () => nestedDrag = null);
+                    },
+                    onHorizontalDragUpdate: (DragUpdateDetails details) {
+                      if (!nestedInReorder) {
+                        nestedDrag.update(details);
+                      } else {
+                        final RenderBox renderBox = nestedListKey.currentContext
+                            .findRenderObject() as RenderBox;
+                        final double dragLocalXOffset =
+                            renderBox.globalToLocal(details.globalPosition).dx;
+                        final ScrollPosition position =
+                            nestedScrollController.position;
+
+                        if (dragLocalXOffset < 50 &&
+                            position.extentBefore > 0) {
+                          final DragUpdateDetails invertedDetails =
+                              DragUpdateDetails(
+                            sourceTimeStamp: details.sourceTimeStamp,
+                            primaryDelta: 10,
+                            delta: Offset(10, details.delta.dy),
+                            globalPosition: details.globalPosition,
+                            localPosition: details.localPosition,
+                          );
+                          nestedDrag.update(invertedDetails);
+                        } else if (dragLocalXOffset >
+                                (renderBox.constraints.maxWidth - 50) &&
+                            position.extentAfter > 0) {
+                          final DragUpdateDetails invertedDetails =
+                              DragUpdateDetails(
+                            sourceTimeStamp: details.sourceTimeStamp,
+                            primaryDelta: -10,
+                            delta: Offset(-10, details.delta.dy),
+                            globalPosition: details.globalPosition,
+                            localPosition: details.localPosition,
+                          );
+                          nestedDrag.update(invertedDetails);
+                        }
+                      }
+                    },
+                    onHorizontalDragCancel: () {
+                      nestedDrag?.cancel();
+                    },
+                    onHorizontalDragEnd: (DragEndDetails details) {
+                      nestedDrag?.end(details);
+                    },
+                    child: ImplicitlyAnimatedReorderableList(
+                        shrinkWrap: true,
+                        scrollDirection: Axis.horizontal,
+                        physics: const NeverScrollableScrollPhysics(),
+                        items: nestedList,
+                        areItemsTheSame: (oldItem, newItem) =>
+                            oldItem == newItem,
+                        onReorderStarted: (item, from) {
+                          setState(() {
+                            nestedInReorder = true;
+                          });
+                        },
+                        onReorderFinished: (item, from, to, newList) {
+                          setState(() {
+                            nestedInReorder = false;
+                            nestedList
+                              ..clear()
+                              ..addAll(newList as List<String>);
+                          });
+                        },
+                        itemBuilder: (context, itemAnimation, item, index) {
+                          return Reorderable(
+                            key: ValueKey(item),
+                            builder: (context, dragAnimation, inDrag) {
+                              return Handle(
+                                controller: nestedScrollController,
+                                child: Card(
+                                  child: Container(
+                                    width: 80,
+                                    color: inDrag ? Colors.grey : null,
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 10),
+                                    child: Center(child: Text(item)),
+                                  ),
+                                ),
+                              );
+                            },
+                          );
+                        }),
+                  )
+                ],
+              ),
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/example/lib/ui/lang_page.dart
+++ b/example/lib/ui/lang_page.dart
@@ -7,6 +7,7 @@ import 'package:implicitly_animated_reorderable_list/implicitly_animated_reorder
 import 'package:implicitly_animated_reorderable_list/transitions.dart';
 
 import '../util/util.dart';
+import 'horizontal_nested_example.dart';
 import 'search_page.dart';
 import 'vertical_nested_example.dart';
 
@@ -39,7 +40,6 @@ class _LanguagePageState extends State<LanguagePage>
 
   ScrollController scrollController;
 
-
   @override
   void initState() {
     super.initState();
@@ -65,7 +65,7 @@ class _LanguagePageState extends State<LanguagePage>
 
     return Scaffold(
         appBar: AppBar(
-          title: const Text('Languages Demo'),
+          title: const Text('Examples'),
           backgroundColor: theme.accentColor,
           actions: <Widget>[
             _buildPopupMenuButton(textTheme),
@@ -117,8 +117,8 @@ class _LanguagePageState extends State<LanguagePage>
                 controller: tabController,
                 children: <Widget>[
                   _buildVerticalAndHorizontalExamples(theme),
-                  VerticalNestedExample(),
-                  _buildHorizontalNestedExample(),
+                  const VerticalNestedExample(),
+                  const HorizontalNestedExample(),
                 ],
               ),
             )
@@ -486,10 +486,6 @@ class _LanguagePageState extends State<LanguagePage>
   void dispose() {
     scrollController.dispose();
     super.dispose();
-  }
-
-  Widget _buildHorizontalNestedExample() {
-    return Container();
   }
 }
 

--- a/example/lib/ui/lang_page.dart
+++ b/example/lib/ui/lang_page.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 
@@ -9,6 +8,7 @@ import 'package:implicitly_animated_reorderable_list/transitions.dart';
 
 import '../util/util.dart';
 import 'search_page.dart';
+import 'vertical_nested_example.dart';
 
 class LanguagePage extends StatefulWidget {
   const LanguagePage({
@@ -32,23 +32,19 @@ class _LanguagePageState extends State<LanguagePage>
     spanish,
     french,
   ];
-  List<String> nestedList = List.generate(20, (i) => "$i");
+
   TabController tabController;
 
   bool inReorder = false;
 
-  GlobalKey nestedListKey = GlobalKey();
-  bool nestedInReorder = false;
   ScrollController scrollController;
-  ScrollController nestedScrollController;
-  Drag nestedDrag;
+
 
   @override
   void initState() {
     super.initState();
     scrollController = ScrollController();
-    nestedScrollController = ScrollController();
-    tabController = TabController(initialIndex: 0, length: 2, vsync: this);
+    tabController = TabController(initialIndex: 0, length: 3, vsync: this);
   }
 
   void onReorderFinished(List<Language> newItems) {
@@ -95,7 +91,18 @@ class _LanguagePageState extends State<LanguagePage>
                   height: 30,
                   child: Center(
                     child: Text(
-                      "Nested Demo",
+                      "Vertical Nested Demo",
+                      style: textTheme.body2.copyWith(
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                ),
+                Container(
+                  height: 30,
+                  child: Center(
+                    child: Text(
+                      "Horizontal Nested Demo",
                       style: textTheme.body2.copyWith(
                         fontSize: 16,
                       ),
@@ -110,7 +117,8 @@ class _LanguagePageState extends State<LanguagePage>
                 controller: tabController,
                 children: <Widget>[
                   _buildVerticalAndHorizontalExamples(theme),
-                  _buildNestedExamples(),
+                  VerticalNestedExample(),
+                  _buildHorizontalNestedExample(),
                 ],
               ),
             )
@@ -480,120 +488,8 @@ class _LanguagePageState extends State<LanguagePage>
     super.dispose();
   }
 
-  Widget _buildNestedExamples() {
-    return Column(
-      children: <Widget>[
-        Expanded(
-          child: SingleChildScrollView(
-            key: nestedListKey,
-            controller: nestedScrollController,
-            physics:
-                nestedInReorder ? const NeverScrollableScrollPhysics() : null,
-            child: Column(
-              children: <Widget>[
-                Card(
-                  child: Container(
-                      height: 60,
-                      child: const Center(child: Text('Sibling Content'))),
-                ),
-                GestureDetector(
-                  onVerticalDragStart: (DragStartDetails details) {
-                    nestedDrag = nestedScrollController.position
-                        .drag(details, () => nestedDrag = null);
-                  },
-                  onVerticalDragUpdate: (DragUpdateDetails details) {
-                    if (!nestedInReorder) {
-                      nestedDrag.update(details);
-                    } else {
-                      final RenderBox renderBox = nestedListKey.currentContext
-                          .findRenderObject() as RenderBox;
-                      final double dragLocalYOffset =
-                          renderBox.globalToLocal(details.globalPosition).dy;
-                      final ScrollPosition position =
-                          nestedScrollController.position;
-
-                      if (dragLocalYOffset < 50 && position.extentBefore > 0) {
-                        final DragUpdateDetails invertedDetails =
-                            DragUpdateDetails(
-                          sourceTimeStamp: details.sourceTimeStamp,
-                          primaryDelta: 10,
-                          delta: Offset(details.delta.dx, 10),
-                          globalPosition: details.globalPosition,
-                          localPosition: details.localPosition,
-                        );
-                        nestedDrag.update(invertedDetails);
-                      } else if (dragLocalYOffset >
-                              (renderBox.constraints.maxHeight - 50) &&
-                          position.extentAfter > 0) {
-                        final DragUpdateDetails invertedDetails =
-                            DragUpdateDetails(
-                          sourceTimeStamp: details.sourceTimeStamp,
-                          primaryDelta: -10,
-                          delta: Offset(details.delta.dx, -10),
-                          globalPosition: details.globalPosition,
-                          localPosition: details.localPosition,
-                        );
-                        nestedDrag.update(invertedDetails);
-                      }
-                    }
-                  },
-                  onVerticalDragCancel: () {
-                    nestedDrag?.cancel();
-                  },
-                  onVerticalDragEnd: (DragEndDetails details) {
-                    nestedDrag?.end(details);
-                  },
-                  child: ImplicitlyAnimatedReorderableList(
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      items: nestedList,
-                      areItemsTheSame: (oldItem, newItem) => oldItem == newItem,
-                      onReorderStarted: (item, from) {
-                        setState(() {
-                          nestedInReorder = true;
-                        });
-                      },
-                      onReorderFinished: (item, from, to, newList) {
-                        setState(() {
-                          nestedInReorder = false;
-                          nestedList
-                            ..clear()
-                            ..addAll(newList as List<String>);
-                        });
-                      },
-                      itemBuilder: (context, itemAnimation, item, index) {
-                        return Reorderable(
-                          key: ValueKey(item),
-                          builder: (context, dragAnimation, inDrag) {
-                            return Card(
-                              child: Container(
-                                height: 60,
-                                color: inDrag ? Colors.grey : null,
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 10),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: <Widget>[
-                                    Center(child: Text(item)),
-                                    Handle(
-                                      controller: nestedScrollController,
-                                      child: Icon(Icons.menu),
-                                    )
-                                  ],
-                                ),
-                              ),
-                            );
-                          },
-                        );
-                      }),
-                )
-              ],
-            ),
-          ),
-        )
-      ],
-    );
+  Widget _buildHorizontalNestedExample() {
+    return Container();
   }
 }
 

--- a/example/lib/ui/search_page.dart
+++ b/example/lib/ui/search_page.dart
@@ -79,10 +79,10 @@ class _LanguageSearchPageState extends State<LanguageSearchPage> {
         title: HighlightText(
           query: text,
           text: lang.nativeName,
-          style: textTheme.bodyText1.copyWith(
+          style: textTheme.body1.copyWith(
             fontSize: 16,
           ),
-          activeStyle: textTheme.bodyText1.copyWith(
+          activeStyle: textTheme.body1.copyWith(
             fontSize: 16,
             fontWeight: FontWeight.w900,
           ),
@@ -90,10 +90,10 @@ class _LanguageSearchPageState extends State<LanguageSearchPage> {
         subtitle: HighlightText(
           query: text,
           text: lang.englishName,
-          style: textTheme.bodyText2.copyWith(
+          style: textTheme.body2.copyWith(
             fontSize: 15,
           ),
-          activeStyle: textTheme.bodyText2.copyWith(
+          activeStyle: textTheme.body2.copyWith(
             fontSize: 15,
             fontWeight: FontWeight.bold,
           ),
@@ -162,7 +162,7 @@ class _LanguageSearchPageState extends State<LanguageSearchPage> {
                       autofocus: true,
                       controller: _controller,
                       textInputAction: TextInputAction.search,
-                      style: textTheme.bodyText1.copyWith(
+                      style: textTheme.body1.copyWith(
                         color: Colors.white,
                         fontSize: 18,
                       ),
@@ -170,7 +170,7 @@ class _LanguageSearchPageState extends State<LanguageSearchPage> {
                         border: InputBorder.none,
                         contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                         hintText: 'Search for a language',
-                        hintStyle: textTheme.bodyText1.copyWith(
+                        hintStyle: textTheme.body1.copyWith(
                           color: Colors.grey.shade200,
                           fontSize: 16,
                         ),

--- a/example/lib/ui/test.dart
+++ b/example/lib/ui/test.dart
@@ -29,7 +29,8 @@ class _FirebasePageState extends State<FirebasePage> {
     );
   }
 
-  Reorderable buildItem(BuildContext context, Animation itemAnimation, Color color, int index) {
+  Reorderable buildItem(
+      BuildContext context, Animation itemAnimation, Color color, int index) {
     return Reorderable(
       key: ValueKey(color),
       builder: (context, dragAnimation, _) {
@@ -39,11 +40,13 @@ class _FirebasePageState extends State<FirebasePage> {
             color: color,
             height: 56,
             width: double.infinity,
-            border: const Border.symmetric(
-              vertical: BorderSide(
-                color: Colors.grey,
-              ),
-            ),
+            border: const Border(
+                top: BorderSide(
+                  color: Colors.grey,
+                ),
+                bottom: BorderSide(
+                  color: Colors.grey,
+                )),
           ),
         );
       },

--- a/example/lib/ui/vertical_nested_example.dart
+++ b/example/lib/ui/vertical_nested_example.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:implicitly_animated_reorderable_list/implicitly_animated_reorderable_list.dart';
+
+class VerticalNestedExample extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() {
+    return VerticalNestedExampleState();
+  }
+}
+
+class VerticalNestedExampleState extends State<VerticalNestedExample> {
+  List<String> nestedList = List.generate(20, (i) => "$i");
+  GlobalKey nestedListKey = GlobalKey();
+  bool nestedInReorder = false;
+  ScrollController nestedScrollController;
+  Drag nestedDrag;
+
+  @override
+  void initState() {
+    super.initState();
+    nestedScrollController = ScrollController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Expanded(
+          child: SingleChildScrollView(
+            key: nestedListKey,
+            controller: nestedScrollController,
+            physics:
+                nestedInReorder ? const NeverScrollableScrollPhysics() : null,
+            child: Column(
+              children: <Widget>[
+                Card(
+                  child: Container(
+                      height: 60,
+                      child: const Center(child: Text('Sibling Content'))),
+                ),
+                GestureDetector(
+                  onVerticalDragStart: (DragStartDetails details) {
+                    nestedDrag = nestedScrollController.position
+                        .drag(details, () => nestedDrag = null);
+                  },
+                  onVerticalDragUpdate: (DragUpdateDetails details) {
+                    if (!nestedInReorder) {
+                      nestedDrag.update(details);
+                    } else {
+                      final RenderBox renderBox = nestedListKey.currentContext
+                          .findRenderObject() as RenderBox;
+                      final double dragLocalYOffset =
+                          renderBox.globalToLocal(details.globalPosition).dy;
+                      final ScrollPosition position =
+                          nestedScrollController.position;
+
+                      if (dragLocalYOffset < 50 && position.extentBefore > 0) {
+                        final DragUpdateDetails invertedDetails =
+                            DragUpdateDetails(
+                          sourceTimeStamp: details.sourceTimeStamp,
+                          primaryDelta: 10,
+                          delta: Offset(details.delta.dx, 10),
+                          globalPosition: details.globalPosition,
+                          localPosition: details.localPosition,
+                        );
+                        nestedDrag.update(invertedDetails);
+                      } else if (dragLocalYOffset >
+                              (renderBox.constraints.maxHeight - 50) &&
+                          position.extentAfter > 0) {
+                        final DragUpdateDetails invertedDetails =
+                            DragUpdateDetails(
+                          sourceTimeStamp: details.sourceTimeStamp,
+                          primaryDelta: -10,
+                          delta: Offset(details.delta.dx, -10),
+                          globalPosition: details.globalPosition,
+                          localPosition: details.localPosition,
+                        );
+                        nestedDrag.update(invertedDetails);
+                      }
+                    }
+                  },
+                  onVerticalDragCancel: () {
+                    nestedDrag?.cancel();
+                  },
+                  onVerticalDragEnd: (DragEndDetails details) {
+                    nestedDrag?.end(details);
+                  },
+                  child: ImplicitlyAnimatedReorderableList(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      items: nestedList,
+                      areItemsTheSame: (oldItem, newItem) => oldItem == newItem,
+                      onReorderStarted: (item, from) {
+                        setState(() {
+                          nestedInReorder = true;
+                        });
+                      },
+                      onReorderFinished: (item, from, to, newList) {
+                        setState(() {
+                          nestedInReorder = false;
+                          nestedList
+                            ..clear()
+                            ..addAll(newList as List<String>);
+                        });
+                      },
+                      itemBuilder: (context, itemAnimation, item, index) {
+                        return Reorderable(
+                          key: ValueKey(item),
+                          builder: (context, dragAnimation, inDrag) {
+                            return Card(
+                              child: Container(
+                                height: 60,
+                                color: inDrag ? Colors.grey : null,
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 10),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: <Widget>[
+                                    Center(child: Text(item)),
+                                    Handle(
+                                      controller: nestedScrollController,
+                                      child: Icon(Icons.menu),
+                                    )
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      }),
+                )
+              ],
+            ),
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/example/lib/ui/vertical_nested_example.dart
+++ b/example/lib/ui/vertical_nested_example.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:implicitly_animated_reorderable_list/implicitly_animated_reorderable_list.dart';
 
 class VerticalNestedExample extends StatefulWidget {
+  const VerticalNestedExample();
+
   @override
   State<StatefulWidget> createState() {
     return VerticalNestedExampleState();
@@ -32,8 +34,6 @@ class VerticalNestedExampleState extends State<VerticalNestedExample> {
           child: SingleChildScrollView(
             key: nestedListKey,
             controller: nestedScrollController,
-            physics:
-                nestedInReorder ? const NeverScrollableScrollPhysics() : null,
             child: Column(
               children: <Widget>[
                 Card(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -169,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/handle.dart
+++ b/lib/src/handle.dart
@@ -53,12 +53,10 @@ class _HandleState extends State<Handle> {
 
   bool _inDrag = false;
 
+  double _initialExtentBefore;
   double _initialOffset;
   double _currentOffset;
   double get _delta => (_currentOffset ?? 0) - (_initialOffset ?? 0);
-
-  double startExtentBefore;
-  Offset startOffset;
 
   void _onDragStarted(Offset pointer) {
     _removeScrollListener();
@@ -79,8 +77,7 @@ class _HandleState extends State<Handle> {
 
   void _onDragEnded() {
     _inDrag = false;
-    startExtentBefore = null;
-    startOffset = null;
+    _initialExtentBefore = null;
 
     _handler?.cancel();
     _list?.onDragEnded();
@@ -124,8 +121,7 @@ class _HandleState extends State<Handle> {
     return Listener(
       onPointerDown: (event) {
         final pointer = event.localPosition;
-        startExtentBefore = widget.controller?.position?.extentBefore ?? 0;
-        startOffset = event.localPosition;
+        _initialExtentBefore = widget.controller?.position?.extentBefore ?? 0;
 
         if (!_inDrag) {
           _cancelReorder();
@@ -142,14 +138,14 @@ class _HandleState extends State<Handle> {
         if (_isVertical) {
           final double position =
               ((widget.controller?.position?.extentBefore ?? 0) -
-                      startExtentBefore) +
-                  (event.localPosition.dy - startOffset.dy);
+                      _initialExtentBefore) +
+                  event.localPosition.dy;
           pointer = Offset(0, position);
         } else {
           final double position =
               ((widget.controller?.position?.extentBefore ?? 0) -
-                      startExtentBefore) +
-                  (event.localPosition.dx - startOffset.dx);
+                      _initialExtentBefore) +
+                  event.localPosition.dx;
           pointer = Offset(position, 0);
         }
         final delta = _isVertical ? event.delta.dy : event.delta.dx;

--- a/lib/src/implicitly_animated_reorderable_list.dart
+++ b/lib/src/implicitly_animated_reorderable_list.dart
@@ -498,7 +498,7 @@ class ImplicitlyAnimatedReorderableListState<E>
     postFrame(() {
       _listSize = isVertical ? listKey.height : listKey.width;
 
-      if (needsRebuild) setState(() {});
+      if (needsRebuild && mounted) setState(() {});
     });
   }
 

--- a/lib/src/implicitly_animated_reorderable_list.dart
+++ b/lib/src/implicitly_animated_reorderable_list.dart
@@ -8,9 +8,11 @@ import 'src.dart';
 
 typedef ReorderStartedCallback<E> = void Function(E item, int index);
 
-typedef ReorderFinishedCallback<E> = void Function(E item, int from, int to, List<E> newItems);
+typedef ReorderFinishedCallback<E> = void Function(
+    E item, int from, int to, List<E> newItems);
 
-class ImplicitlyAnimatedReorderableList<E> extends ImplicitlyAnimatedListBase<Reorderable, E> {
+class ImplicitlyAnimatedReorderableList<E>
+    extends ImplicitlyAnimatedListBase<Reorderable, E> {
   /// Whether the scroll view scrolls in the reading direction.
   ///
   /// Defaults to false.
@@ -131,15 +133,18 @@ class ImplicitlyAnimatedReorderableList<E> extends ImplicitlyAnimatedListBase<Re
         );
 
   @override
-  ImplicitlyAnimatedReorderableListState<E> createState() => ImplicitlyAnimatedReorderableListState<E>();
+  ImplicitlyAnimatedReorderableListState<E> createState() =>
+      ImplicitlyAnimatedReorderableListState<E>();
 
   static ImplicitlyAnimatedReorderableListState of(BuildContext context) {
-    return context.findAncestorStateOfType<ImplicitlyAnimatedReorderableListState>();
+    return context
+        .findAncestorStateOfType<ImplicitlyAnimatedReorderableListState>();
   }
 }
 
 class ImplicitlyAnimatedReorderableListState<E>
-    extends ImplicitlyAnimatedListBaseState<Reorderable, ImplicitlyAnimatedReorderableList<E>, E> {
+    extends ImplicitlyAnimatedListBaseState<Reorderable,
+        ImplicitlyAnimatedReorderableList<E>, E> {
   GlobalKey _dragKey;
   Timer _scrollAdjuster;
 
@@ -267,7 +272,8 @@ class ImplicitlyAnimatedReorderableListState<E>
         _closestList.add(item);
       } else {
         final position = isVertical ? item.center.dy : item.center.dx;
-        if ((_motionUp && dragStart < position) || (!_motionUp && dragEnd > position)) {
+        if ((_motionUp && dragStart < position) ||
+            (!_motionUp && dragEnd > position)) {
           item.distance = ((_up ? dragStart : dragEnd) - position).abs();
           _closestList.add(item);
         }
@@ -370,12 +376,14 @@ class ImplicitlyAnimatedReorderableListState<E>
   void _adjustScrollPositionWhenNecessary() {
     _scrollAdjuster?.cancel();
     _scrollAdjuster = Timer.periodic(const Duration(milliseconds: 16), (_) {
-      if ((_up && scrollOffset <= 0) || (!_up && scrollOffset >= _maxScrollOffset)) return;
+      if ((_up && scrollOffset <= 0) ||
+          (!_up && scrollOffset >= _maxScrollOffset)) return;
 
       final dragBox = _dragKey?.renderBox;
       if (dragBox == null) return;
 
-      final dragOffset = dragBox.localToGlobal(Offset.zero, ancestor: context.renderBox);
+      final dragOffset =
+          dragBox.localToGlobal(Offset.zero, ancestor: context.renderBox);
       final dragItemStart = isVertical ? dragOffset.dy : dragOffset.dx;
       final dragItemEnd = dragItemStart + dragSize;
 
@@ -424,7 +432,8 @@ class ImplicitlyAnimatedReorderableListState<E>
       _cancelDrag();
     };
 
-    final delta = closest != dragItem ? closest.start - dragStart : -_pointerDelta;
+    final delta =
+        closest != dragItem ? closest.start - dragStart : -_pointerDelta;
 
     _dispatchMove(
       dragKey,
@@ -464,7 +473,8 @@ class ImplicitlyAnimatedReorderableListState<E>
     _controller.jumpTo(_controller.offset);
   }
 
-  double getTranslation(Key key) => key == dragKey ? _dragDelta : _itemTranslations[key]?.value ?? 0.0;
+  double getTranslation(Key key) =>
+      key == dragKey ? _dragDelta : _itemTranslations[key]?.value ?? 0.0;
 
   void registerItem(ReorderableState item) {
     _items[item.key] = item;
@@ -517,7 +527,8 @@ class ImplicitlyAnimatedReorderableListState<E>
           itemBuilder: (context, index, animation) {
             final item = dataSet[index];
 
-            final Reorderable child = buildItem(context, animation, item, index);
+            final Reorderable child =
+                buildItem(context, animation, item, index);
             postFrame(() => _measureChild(child.key, index));
 
             if (dragKey != null && index == dragIndex) {
@@ -546,7 +557,8 @@ class ImplicitlyAnimatedReorderableListState<E>
           controller: _controller,
           scrollDirection: widget.scrollDirection,
           initialItemCount: newData.length,
-          physics: inDrag ? const NeverScrollableScrollPhysics() : widget.physics,
+          physics:
+              inDrag ? const NeverScrollableScrollPhysics() : widget.physics,
           padding: widget.padding,
           primary: widget.primary,
           reverse: widget.reverse,
@@ -621,7 +633,8 @@ class ImplicitlyAnimatedReorderableListState<E>
         }
       })
       ..addStatusListener((status) {
-        if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
+        if (status == AnimationStatus.completed ||
+            status == AnimationStatus.dismissed) {
           didUpdateList = false;
         }
       });
@@ -663,7 +676,9 @@ class _Item extends Rect implements Comparable<_Item> {
   double distance;
 
   @override
-  int compareTo(_Item other) => distance != null && other.distance != null ? distance.compareTo(other.distance) : -1;
+  int compareTo(_Item other) => distance != null && other.distance != null
+      ? distance.compareTo(other.distance)
+      : -1;
 
   @override
   String toString() => '_Item key: $key, index: $index';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -95,6 +95,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Handle now takes a `ScrollController` from from which it can compute the updated position relative to the scroll controller's offset. Added examples of this usage nested in both vertical and horizontal scrollables. Example code includes gesture detectors for conditionally managing scrolling, which could be adapted and integrated into the widget itself to allow this functionality fully.

Added mounted check to postFrame callback in `ImplicitlyAnimatedReorderableList` to prevent attempts to `setState` after `dispose`.